### PR TITLE
Remove BasePath from the URL path during transformation

### DIFF
--- a/request.go
+++ b/request.go
@@ -76,6 +76,33 @@ func (b *RequestBuilder) Transform(ts ...Transformer) error {
 	return nil
 }
 
+// StripBasePath removes a BasePath from the Path fragment of the URL.
+// StripBasePath must be run before RequestBuilder.ParseURL function.
+func (b *RequestBuilder) StripBasePath(basePath string) error {
+	b.Path = omitBasePath(b.ev.Path, basePath)
+	return nil
+}
+
+// omitBasePath strips out the base path from the given path.
+//
+// It allows to support both API endpoints (default, auto-generated
+// "execute-api" address and configured Base Path Mapping/ with a Custom Domain
+// Name), while preserving the same routing registered on the http.Handler.
+func omitBasePath(path string, basePath string) string {
+	if path == "/" || basePath == "" {
+		return path
+	}
+
+	if strings.HasPrefix(path, "/"+basePath) {
+		path = strings.Replace(path, basePath, "", 1)
+	}
+	if strings.HasPrefix(path, "//") {
+		path = path[1:]
+	}
+
+	return path
+}
+
 // ParseURL provides URL (as a *url.URL) to the RequestBuilder.
 func (b *RequestBuilder) ParseURL() error {
 	// Whether path has been already defined (i.e. processed by previous

--- a/request_test.go
+++ b/request_test.go
@@ -56,8 +56,6 @@ func TestStripBasePath_customDomain(t *testing.T) {
 		e.Path = "/pets"
 		r, err := newRequestStripBasePath(e, "pets")
 		assert.NoError(t, err)
-
-		// 	{"ListItems_WithBasePath_Custom", args{"/pets", basePath}, "/"},
 		assert.Equal(t, "/", r.URL.Path)
 	})
 
@@ -65,8 +63,6 @@ func TestStripBasePath_customDomain(t *testing.T) {
 		e.Path = "/pets/123"
 		r, err := newRequestStripBasePath(e, "pets")
 		assert.NoError(t, err)
-
-		// 	{"GetItem_WithBasePath_Custom", args{"/pets/123", basePath}, "/123"},
 		assert.Equal(t, "/123", r.URL.Path)
 	})
 }


### PR DESCRIPTION
Implementation is based on code found in apex/gateway#4 (there is also some explanation of the problem).