### PR TITLE
Version 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 go_import_path: github.com/piotrkubisa/apigo
 go:
-  - 1.8.x
-  - 1.9.x
   - 1.10.x
+  - 1.11.x
   - tip
 
 script:

--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 [![Documentation](https://godoc.org/github.com/piotrkubisa/apigo?status.svg)](http://godoc.org/github.com/piotrkubisa/apigo)
 [![Build Status](https://travis-ci.org/piotrkubisa/apigo.svg?branch=master)](https://travis-ci.org/piotrkubisa/apigo)
 [![Go Report Card](https://goreportcard.com/badge/github.com/piotrkubisa/apigo)](https://goreportcard.com/report/github.com/piotrkubisa/apigo)
-[![Exago](https://api.exago.io:443/badge/rank/github.com/piotrkubisa/apigo)](https://exago.io/project/github.com/piotrkubisa/apigo)
-[![Exago](https://api.exago.io:443/badge/cov/github.com/piotrkubisa/apigo)](https://exago.io/project/github.com/piotrkubisa/apigo)
-[![Exago](https://api.exago.io:443/badge/thirdparties/github.com/piotrkubisa/apigo)](https://exago.io/project/github.com/piotrkubisa/apigo)
 
 Package `apigo` is an drop-in adapter to AWS Lambda functions (based on `go1.x` runtime) with a AWS API Gateway to easily reuse logic from _serverfull_ `http.Handler`s and provide the same experience for serverless function.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import (
 func main() {
 	http.HandleFunc("/hello", helloHandler)
 
-	apigo.ListenAndServe(http.DefaultServeMux)
+	apigo.ListenAndServe("api.example.com", http.DefaultServeMux)
 }
 
 func helloHandler(w http.ResponseWriter, r *http.Request) {
@@ -64,7 +64,7 @@ import (
 
 func main() {
 	g := &apigo.Gateway{
-		Proxy:   apigo.ProxyFunc(customProxy),
+		Proxy:   &CustomProxy{apigo.DefaultProxy{"api.example.com"}},
 		Handler: routing(),
 	}
 	g.ListenAndServe()
@@ -74,8 +74,12 @@ type contextUsername struct{}
 
 var keyUsername = &contextUsername{}
 
-func customProxy(ctx context.Context, ev events.APIGatewayProxyRequest) (*http.Request, error) {
-	r, err := apigo.DefaultProxy(ctx, ev)
+type CustomProxy struct {
+	apigo.DefaultProxy
+}
+
+func (p *CustomProxy) Transform(ctx context.Context, ev events.APIGatewayProxyRequest) (*http.Request, error) {
+	r, err := p.DefaultProxy.Transform(ctx, ev)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +130,7 @@ import (
 )
 
 func main() {
-	apigo.ListenAndServe(routing())
+	apigo.ListenAndServe("api.example.com", routing())
 }
 
 func routing() http.Handler {

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ func routing() http.Handler {
 }
 ```
 
-## Goroutines
+### Goroutines
 
 If you are going to use `goroutines` in your AWS handler, then it is worth noting you should control its execution (i.e. by using `sync.WaitGroup`), otherwise code in the `goroutine` might be killed after returning a response to AWS API Gateway.
 
@@ -132,7 +132,7 @@ func main() {
 func routing() http.Handler {
 	r := chi.NewRouter()
 
-	r.Post("/{name}", func(w http.ResponseWriter, r *http.Request) {
+	r.Post("/cat", func(w http.ResponseWriter, r *http.Request) {
 		var wg sync.WaitGroup
 		wg.Add(2)
 		go sendIoTMessage(&wg)
@@ -142,7 +142,7 @@ func routing() http.Handler {
 		// Headers, status, payload
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`"Done"`))
+		w.Write([]byte(`"Meow"`))
 	})
 
 	return r

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ func routing() http.Handler {
 
 ### Goroutines
 
-If you are going to use `goroutines` in your AWS handler, then it is worth noting you should control its execution (i.e. by using `sync.WaitGroup`), otherwise code in the `goroutine` might be killed after returning a response to AWS API Gateway.
+If you are going to use `goroutines` in your AWS Lambda handler, then it is worth noting you should control its execution (i.e. by using `sync.WaitGroup`), otherwise code in the `goroutine` might be killed after returning a response to AWS API Gateway.
 
 ```go
 package main

--- a/context_test.go
+++ b/context_test.go
@@ -24,9 +24,9 @@ func TestNewContext(t *testing.T) {
 				SourceIP:                      "1.1.1.1",
 				CognitoAuthenticationType:     "xxx",
 				CognitoAuthenticationProvider: "xxx",
-				UserArn:   "xxx",
-				UserAgent: "xxx",
-				User:      "xxx",
+				UserArn:                       "xxx",
+				UserAgent:                     "xxx",
+				User:                          "xxx",
 			},
 			ResourcePath: "/{id}",
 			Authorizer: map[string]interface{}{
@@ -38,7 +38,7 @@ func TestNewContext(t *testing.T) {
 		},
 	}
 
-	r, _ := DefaultProxy(context.TODO(), ev)
+	r, _ := new(DefaultProxy).Transform(context.TODO(), ev)
 	rc, _ := RequestContext(r.Context())
 
 	assert.Equal(t, "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX", rc.RequestID)
@@ -52,7 +52,7 @@ func TestNewRequest_context(t *testing.T) {
 	ev := events.APIGatewayProxyRequest{}
 	ctx := context.WithValue(context.TODO(), testContextKey, "value")
 
-	r, err := DefaultProxy(ctx, ev)
+	r, err := new(DefaultProxy).Transform(ctx, ev)
 	assert.NoError(t, err)
 
 	v := r.Context().Value(testContextKey)

--- a/context_test.go
+++ b/context_test.go
@@ -44,3 +44,17 @@ func TestNewContext(t *testing.T) {
 	assert.Equal(t, "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX", rc.RequestID)
 	assert.Equal(t, "johndoe", rc.Authorizer["cognitoUsername"])
 }
+
+func TestNewRequest_context(t *testing.T) {
+	type testRequestContextKey struct{}
+	var testContextKey = &testRequestContextKey{}
+
+	ev := events.APIGatewayProxyRequest{}
+	ctx := context.WithValue(context.TODO(), testContextKey, "value")
+
+	r, err := DefaultProxy(ctx, ev)
+	assert.NoError(t, err)
+
+	v := r.Context().Value(testContextKey)
+	assert.Equal(t, "value", v)
+}

--- a/context_test.go
+++ b/context_test.go
@@ -16,29 +16,29 @@ func TestNewContext(t *testing.T) {
 			Stage:      "testing",
 			RequestID:  "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
 			Identity: events.APIGatewayRequestIdentity{
-				CognitoIdentityPoolID:         "",
-				AccountID:                     "",
-				CognitoIdentityID:             "",
-				Caller:                        "",
-				APIKey:                        "",
+				CognitoIdentityPoolID:         "xxx",
+				AccountID:                     "xxx",
+				CognitoIdentityID:             "xxx",
+				Caller:                        "xxx",
+				APIKey:                        "xxx",
 				SourceIP:                      "1.1.1.1",
-				CognitoAuthenticationType:     "",
-				CognitoAuthenticationProvider: "",
-				UserArn:   "",
-				UserAgent: "PostmanRuntime/7.1.1",
-				User:      "",
+				CognitoAuthenticationType:     "xxx",
+				CognitoAuthenticationProvider: "xxx",
+				UserArn:   "xxx",
+				UserAgent: "xxx",
+				User:      "xxx",
 			},
 			ResourcePath: "/{id}",
 			Authorizer: map[string]interface{}{
 				"cognitoUsername": "johndoe",
-				"principalId":     "XXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+				"principalId":     "xxxx",
 			},
 			HTTPMethod: "GET",
 			APIID:      "XXXXXXXXXX",
 		},
 	}
 
-	r, _ := NewRequest(context.TODO(), ev)
+	r, _ := DefaultProxy(context.TODO(), ev)
 	rc, _ := RequestContext(r.Context())
 
 	assert.Equal(t, "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX", rc.RequestID)

--- a/gateway.go
+++ b/gateway.go
@@ -18,21 +18,21 @@ type Gateway struct {
 // NewGateway creates new Gateway, which utilizes handler
 // (or http.DefaultServeMux if nil passed) as a Gateway.Handler and
 // apigo.http.DefaultProxy as a Gateway.Proxy.
-func NewGateway(handler http.Handler) *Gateway {
+func NewGateway(host string, handler http.Handler) *Gateway {
 	if handler == nil {
 		handler = http.DefaultServeMux
 	}
 
 	return &Gateway{
 		Handler: handler,
-		Proxy:   ProxyFunc(DefaultProxy),
+		Proxy:   &DefaultProxy{host},
 	}
 }
 
 // ListenAndServe is a drop-in replacement for http.ListenAndServe for use
 // within AWS Lambda.
-func ListenAndServe(h http.Handler) {
-	NewGateway(h).ListenAndServe()
+func ListenAndServe(host string, h http.Handler) {
+	NewGateway(host, h).ListenAndServe()
 }
 
 // ListenAndServe registers a listener of AWS Lambda events.

--- a/gateway.go
+++ b/gateway.go
@@ -31,17 +31,13 @@ func NewGateway(handler http.Handler) *Gateway {
 
 // ListenAndServe is a drop-in replacement for http.ListenAndServe for use
 // within AWS Lambda.
-//
-// NOTE: First, ignored argument to this function was ignored, because it was
-// left to have the same signature of function as apex/gateway's ListenAndServe.
-func ListenAndServe(_ string, h http.Handler) error {
-	return NewGateway(h).ListenAndServe()
+func ListenAndServe(h http.Handler) {
+	NewGateway(h).ListenAndServe()
 }
 
 // ListenAndServe registers a listener of AWS Lambda events.
-func (g *Gateway) ListenAndServe() error {
+func (g *Gateway) ListenAndServe() {
 	lambda.Start(g.Serve)
-	return nil
 }
 
 // Serve handles incoming event from AWS Lambda by wraping them into

--- a/gateway.go
+++ b/gateway.go
@@ -8,30 +8,39 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 )
 
+// Gateway mimics the http.Server definition and takes care of proxying
+// AWS Lambda event to http.Request via Proxy and then handling it using Handler
 type Gateway struct {
-	Handler      http.Handler
-	RequestProxy RequestTransformer
+	Proxy   Proxy
+	Handler http.Handler
+}
+
+// NewGateway creates new Gateway, which utilizes handler
+// (or http.DefaultServeMux if nil passed) as a Gateway.Handler and
+// apigo.http.DefaultProxy as a Gateway.Proxy.
+func NewGateway(handler http.Handler) *Gateway {
+	if handler == nil {
+		handler = http.DefaultServeMux
+	}
+
+	return &Gateway{
+		Handler: handler,
+		Proxy:   ProxyFunc(DefaultProxy),
+	}
 }
 
 // ListenAndServe is a drop-in replacement for http.ListenAndServe for use
 // within AWS Lambda.
 //
 // NOTE: First, ignored argument to this function was ignored, because it was
-// left to have the same signature of function, but also to behave as
-// apex/gateway's ListenAndServe.
+// left to have the same signature of function as apex/gateway's ListenAndServe.
 func ListenAndServe(_ string, h http.Handler) error {
-	g := &Gateway{Handler: h}
-	return g.ListenAndServe()
+	return NewGateway(h).ListenAndServe()
 }
 
 // ListenAndServe registers a listener of AWS Lambda events.
 func (g *Gateway) ListenAndServe() error {
-	if g.Handler == nil {
-		g.Handler = http.DefaultServeMux
-	}
-
 	lambda.Start(g.Serve)
-
 	return nil
 }
 
@@ -39,11 +48,7 @@ func (g *Gateway) ListenAndServe() error {
 // http.Request which is further processed by http.Handler to reply
 // as a APIGatewayProxyResponse.
 func (g *Gateway) Serve(ctx context.Context, e events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	if g.RequestProxy == nil {
-		g.RequestProxy = NewRequest
-	}
-
-	r, err := g.RequestProxy(ctx, e)
+	r, err := g.Proxy.Transform(ctx, e)
 	if err != nil {
 		return events.APIGatewayProxyResponse{}, err
 	}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -15,64 +15,17 @@ func BenchmarkGateway_Serve(b *testing.B) {
 		Proxy:   apigo.ProxyFunc(apigo.DefaultProxy),
 	}
 
-	sampleEvent := events.APIGatewayProxyRequest{
-		Resource:   "/{proxy+}",
-		Path:       "/_version",
-		HTTPMethod: "GET",
-		Headers: map[string]string{
-			"Accept":                       "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
-			"Accept-Encoding":              "gzip, deflate, br",
-			"Accept-Language":              "en-US,en;q=0.9",
-			"CloudFront-Forwarded-Proto":   "https",
-			"CloudFront-Is-Desktop-Viewer": "true",
-			"CloudFront-Is-Mobile-Viewer":  "false",
-			"CloudFront-Is-SmartTV-Viewer": "false",
-			"CloudFront-Is-Tablet-Viewer":  "false",
-			"CloudFront-Viewer-Country":    "DE",
-			"Host":              "tester1337.execute-api.eu-west-1.amazonaws.com",
-			"User-Agent":        "Undefined/1.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36",
-			"Via":               "2.0 cccccccccccccccccccccccccccccccc.cloudfront.net (CloudFront)",
-			"X-Amz-Cf-Id":       "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee_eeeeeeeeeeeee==",
-			"X-Amzn-Trace-Id":   "Root=1-aaaaaaaa-bbbbbbbbbbbbbbbbbbbbbbbb",
-			"X-Forwarded-For":   "0.1.2.225, 0.137.255.255",
-			"X-Forwarded-Port":  "443",
-			"X-Forwarded-Proto": "https",
-			"dnt":               "1",
-			"upgrade-insecure-requests": "1",
-		},
-		QueryStringParameters: nil,
-		PathParameters: map[string]string{
-			"proxy": "hello",
-		},
-		StageVariables: nil,
-		RequestContext: events.APIGatewayProxyRequestContext{
-			AccountID:  "123456789012",
-			ResourceID: "abc123",
-			Stage:      "prod",
-			RequestID:  "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-			Identity: events.APIGatewayRequestIdentity{
-				CognitoIdentityPoolID:         "",
-				AccountID:                     "",
-				CognitoIdentityID:             "",
-				Caller:                        "",
-				APIKey:                        "",
-				SourceIP:                      "0.1.2.225",
-				CognitoAuthenticationType:     "",
-				CognitoAuthenticationProvider: "",
-				UserArn:   "",
-				UserAgent: "Undefined/1.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36",
-				User:      "",
-			},
-			ResourcePath: "/{proxy+}",
-			Authorizer:   nil,
-			HTTPMethod:   "GET",
-			APIID:        "tester1337",
-		},
-		Body: "",
+	payload, err := ioutil.ReadFile("./vendor/github.com/aws/aws-lambda-go/events/testdata/apigw-request.json")
+	if err != nil {
+		panic(err)
+	}
+	var ev events.APIGatewayProxyRequest
+	if err := json.Unmarshal(payload, &ev); err != nil {
+		panic(err)
 	}
 
 	for i := 0; i < b.N; i++ {
-		g.Serve(context.TODO(), sampleEvent)
+		g.Serve(context.TODO(), ev)
 	}
 }
 

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -12,10 +12,7 @@ import (
 )
 
 func BenchmarkGateway_Serve(b *testing.B) {
-	g := apigo.Gateway{
-		Handler: http.HandlerFunc(helloHandler),
-		Proxy:   apigo.ProxyFunc(apigo.DefaultProxy),
-	}
+	g := apigo.NewGateway("api.example.com", http.HandlerFunc(helloHandler))
 
 	payload, err := ioutil.ReadFile("./vendor/github.com/aws/aws-lambda-go/events/testdata/apigw-request.json")
 	if err != nil {

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -1,0 +1,19 @@
+package apigo_test
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/piotrkubisa/apigo"
+)
+
+func helloHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusTeapot)
+	w.Write([]byte(`"Hello World"`))
+}
+
+func Example() {
+	http.HandleFunc("/", helloHandler)
+	log.Fatal(apigo.ListenAndServe("", nil))
+}

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -2,6 +2,8 @@ package apigo_test
 
 import (
 	"context"
+	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"testing"
 

--- a/proxy.go
+++ b/proxy.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/pkg/errors"
 )
 
 // Proxy transforms an event and context provided from the API Gateway
@@ -22,26 +23,50 @@ func (f ProxyFunc) Transform(ctx context.Context, ev events.APIGatewayProxyReque
 	return f(ctx, ev)
 }
 
+// DefaultProxy is a default proxy for AWS API Gateway events
 type DefaultProxy struct {
 	Host string
 }
 
-// DefaultProxy returns a new http.Request created from the given Lambda event.
+// Transform returns a new http.Request created from the given Lambda event.
 func (p *DefaultProxy) Transform(ctx context.Context, ev events.APIGatewayProxyRequest) (*http.Request, error) {
 	r := NewRequest(ctx, ev)
-	r.Host = p.Host
 
-	err := r.CreateRequest()
+	req, err := r.CreateRequest(p.Host)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "creating request")
 	}
 
-	r.AttachContext()
-	r.SetRemoteAddr()
-	r.SetHeaderFields()
-	r.SetContentLength()
-	r.SetCustomHeaders()
-	r.SetXRayHeader()
+	r.AttachContext(req)
+	r.SetRemoteAddr(req)
+	r.SetHeaderFields(req)
+	r.SetContentLength(req)
+	r.SetCustomHeaders(req)
+	r.SetXRayHeader(req)
 
-	return r.Request, nil
+	return req, nil
+}
+
+type StripBasePathProxy struct {
+	Host     string
+	BasePath string
+}
+
+func (p *StripBasePathProxy) Transform(ctx context.Context, ev events.APIGatewayProxyRequest) (*http.Request, error) {
+	r := NewRequest(ctx, ev)
+	r.StripBasePath(p.BasePath)
+
+	req, err := r.CreateRequest(p.Host)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating request")
+	}
+
+	r.AttachContext(req)
+	r.SetRemoteAddr(req)
+	r.SetHeaderFields(req)
+	r.SetContentLength(req)
+	r.SetCustomHeaders(req)
+	r.SetXRayHeader(req)
+
+	return req, nil
 }

--- a/proxy.go
+++ b/proxy.go
@@ -36,12 +36,12 @@ func (p *DefaultProxy) Transform(ctx context.Context, ev events.APIGatewayProxyR
 		return nil, err
 	}
 
-	AttachContext(r)
-	SetRemoteAddr(r)
-	SetHeaderFields(r)
-	SetContentLength(r)
-	SetCustomHeaders(r)
-	SetXRayHeader(r)
+	r.AttachContext()
+	r.SetRemoteAddr()
+	r.SetHeaderFields()
+	r.SetContentLength()
+	r.SetCustomHeaders()
+	r.SetXRayHeader()
 
 	return r.Request, nil
 }

--- a/proxy.go
+++ b/proxy.go
@@ -36,14 +36,12 @@ func (p *DefaultProxy) Transform(ctx context.Context, ev events.APIGatewayProxyR
 		return nil, err
 	}
 
-	r.Transform(
-		AttachContext,
-		SetRemoteAddr,
-		SetHeaderFields,
-		SetContentLength,
-		SetCustomHeaders,
-		SetXRayHeader,
-	)
+	AttachContext(r)
+	SetRemoteAddr(r)
+	SetHeaderFields(r)
+	SetContentLength(r)
+	SetCustomHeaders(r)
+	SetXRayHeader(r)
 
 	return r.Request, nil
 }

--- a/proxy.go
+++ b/proxy.go
@@ -1,0 +1,44 @@
+package apigo
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+// Proxy transforms an event and context provided from the API Gateway
+// to the http.Request.
+type Proxy interface {
+	Transform(context.Context, events.APIGatewayProxyRequest) (*http.Request, error)
+}
+
+// ProxyFunc implements the Proxy interface to allow use of ordinary function
+// as a handler.
+type ProxyFunc func(context.Context, events.APIGatewayProxyRequest) (*http.Request, error)
+
+// Transform calls f(ctx, ev).
+func (f ProxyFunc) Transform(ctx context.Context, ev events.APIGatewayProxyRequest) (*http.Request, error) {
+	return f(ctx, ev)
+}
+
+// DefaultProxy returns a new http.Request created from the given Lambda event.
+func DefaultProxy(ctx context.Context, ev events.APIGatewayProxyRequest) (*http.Request, error) {
+	r := NewRequest(ctx, ev)
+
+	err := r.CreateRequest()
+	if err != nil {
+		return nil, err
+	}
+
+	r.Transform(
+		AttachContext,
+		SetRemoteAddr,
+		SetHeaderFields,
+		SetContentLength,
+		SetCustomHeaders,
+		SetXRayHeader,
+	)
+
+	return r.Request, nil
+}

--- a/proxy.go
+++ b/proxy.go
@@ -22,9 +22,14 @@ func (f ProxyFunc) Transform(ctx context.Context, ev events.APIGatewayProxyReque
 	return f(ctx, ev)
 }
 
+type DefaultProxy struct {
+	Host string
+}
+
 // DefaultProxy returns a new http.Request created from the given Lambda event.
-func DefaultProxy(ctx context.Context, ev events.APIGatewayProxyRequest) (*http.Request, error) {
+func (p *DefaultProxy) Transform(ctx context.Context, ev events.APIGatewayProxyRequest) (*http.Request, error) {
 	r := NewRequest(ctx, ev)
+	r.Host = p.Host
 
 	err := r.CreateRequest()
 	if err != nil {

--- a/request.go
+++ b/request.go
@@ -21,6 +21,7 @@ type Request struct {
 	Event   events.APIGatewayProxyRequest
 
 	Path    string
+	Host    string
 	URL     *url.URL
 	Body    *bytes.Reader
 	Request *http.Request
@@ -102,7 +103,7 @@ func (r *Request) ParseURL() (*url.URL, error) {
 	u.RawQuery = q.Encode()
 
 	// Host
-	u.Host = r.Event.Headers["Host"]
+	u.Host = r.Host
 
 	return u, nil
 }

--- a/request.go
+++ b/request.go
@@ -118,7 +118,7 @@ func (r *Request) ParseBody() error {
 
 // AttachContext attaches events' RequestContext to the http.Request.
 func (r *Request) AttachContext(req *http.Request) {
-	req = req.WithContext(NewContext(r.Context, r.Event))
+	*req = *req.WithContext(NewContext(r.Context, r.Event))
 }
 
 // SetRemoteAddr sets RemoteAddr to the request.

--- a/request.go
+++ b/request.go
@@ -98,12 +98,7 @@ func (r *Request) ParseURL() (*url.URL, error) {
 	}
 
 	// Query-string
-	q := u.Query()
-	for k, qs := range r.Event.MultiValueQueryStringParameters {
-		for _, v := range qs {
-			q.Add(k, v)
-		}
-	}
+	q := url.Values(r.Event.MultiValueQueryStringParameters)
 	u.RawQuery = q.Encode()
 
 	// Host

--- a/request.go
+++ b/request.go
@@ -38,10 +38,8 @@ func NewRequest(ctx context.Context, ev events.APIGatewayProxyRequest) *Request 
 
 // StripBasePath removes a BasePath from the Path fragment of the URL.
 // StripBasePath must be run before RequestBuilder.ParseURL function.
-func StripBasePath(basePath string) Transformer {
-	return func(r *Request) {
-		r.Path = omitBasePath(r.Event.Path, basePath)
-	}
+func StripBasePath(r *Request, basePath string) {
+	r.Path = omitBasePath(r.Event.Path, basePath)
 }
 
 // omitBasePath strips out the base path from the given path.
@@ -120,16 +118,6 @@ func (r *Request) ParseBody() error {
 	}
 	r.Body = bytes.NewReader(body)
 	return nil
-}
-
-// Transformer transforms event from AWS API Gateway to the http.Request.
-type Transformer func(r *Request)
-
-// Transform AWS API Gateway event to a http.Request.
-func (r *Request) Transform(ts ...Transformer) {
-	for _, p := range ts {
-		p(r)
-	}
 }
 
 // AttachContext attaches events' RequestContext to the http.Request.

--- a/request.go
+++ b/request.go
@@ -1,6 +1,7 @@
 package apigo
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -13,74 +14,33 @@ import (
 	"github.com/pkg/errors"
 )
 
-// RequestTransformer is a function which transforms an event and context
-// provided from the API Gateway to http.Request.
-type RequestTransformer func(context.Context, events.APIGatewayProxyRequest) (*http.Request, error)
-
-// NewRequest returns a new http.Request created from the given Lambda event.
-func NewRequest(ctx context.Context, ev events.APIGatewayProxyRequest) (*http.Request, error) {
-	b := NewRequestBuilder(ctx, ev)
-	err := b.Transform(b.DefaultTransforms()...)
-	return b.Request, err
-}
-
-// RequestBuilder is an wrapper which helps transforming event from AWS API
+// Request is an wrapper which helps transforming event from AWS API
 // Gateway as a http.Request.
-type RequestBuilder struct {
-	ctx context.Context
-	ev  events.APIGatewayProxyRequest
+type Request struct {
+	Context context.Context
+	Event   events.APIGatewayProxyRequest
 
 	Path    string
 	URL     *url.URL
-	Body    *strings.Reader
+	Body    *bytes.Reader
 	Request *http.Request
 }
 
-// NewRequestBuilder defines new RequestBuilder with context and event data
+// NewRequest defines new RequestBuilder with context and event data
 // provided from the API Gateway.
-func NewRequestBuilder(ctx context.Context, ev events.APIGatewayProxyRequest) *RequestBuilder {
-	return &RequestBuilder{ctx: ctx, ev: ev}
-}
-
-// DefaultTransforms returns a collection of Transformer functions which all
-// used by apigo during event-to-request transformation.
-func (b *RequestBuilder) DefaultTransforms() []Transformer {
-	return []Transformer{
-		b.ParseURL,
-		b.ParseBody,
-		b.CreateRequest,
-		b.AttachContext,
-		b.SetRemoteAddr,
-		b.SetHeaderFields,
-		b.SetContentLength,
-		b.SetCustomHeaders,
-		b.SetXRayHeader,
+func NewRequest(ctx context.Context, ev events.APIGatewayProxyRequest) *Request {
+	return &Request{
+		Context: ctx,
+		Event:   ev,
 	}
-}
-
-// Transformer transforms event from AWS API Gateway to the http.Request.
-type Transformer func() error
-
-// Transform AWS API Gateway event to a http.Request.
-func (b *RequestBuilder) Transform(ts ...Transformer) error {
-	if ts == nil || len(ts) == 0 {
-		return errors.New("no transformers defined")
-	}
-
-	for _, p := range ts {
-		if err := p(); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // StripBasePath removes a BasePath from the Path fragment of the URL.
 // StripBasePath must be run before RequestBuilder.ParseURL function.
-func (b *RequestBuilder) StripBasePath(basePath string) error {
-	b.Path = omitBasePath(b.ev.Path, basePath)
-	return nil
+func StripBasePath(basePath string) Transformer {
+	return func(r *Request) {
+		r.Path = omitBasePath(r.Event.Path, basePath)
+	}
 }
 
 // omitBasePath strips out the base path from the given path.
@@ -103,101 +63,111 @@ func omitBasePath(path string, basePath string) string {
 	return path
 }
 
+// CreateRequest provides *http.Request to the RequestBuilder.
+func (r *Request) CreateRequest() error {
+	u, err := r.ParseURL()
+	if err != nil {
+		return err
+	}
+	if err := r.ParseBody(); err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(r.Event.HTTPMethod, u.String(), r.Body)
+	if err != nil {
+		return errors.Wrap(err, "creating request")
+	}
+
+	r.Request = req
+	return nil
+}
+
 // ParseURL provides URL (as a *url.URL) to the RequestBuilder.
-func (b *RequestBuilder) ParseURL() error {
+func (r *Request) ParseURL() (*url.URL, error) {
 	// Whether path has been already defined (i.e. processed by previous
 	// function) then use it, otherwise use path from the event.
-	path := b.Path
+	path := r.Path
 	if len(path) == 0 {
-		path = b.ev.Path
+		path = r.Event.Path
 	}
 
 	// Parse URL to *url.URL
 	u, err := url.Parse(path)
 	if err != nil {
-		return errors.Wrap(err, "parsing path")
+		return nil, errors.Wrap(err, "parsing path")
 	}
 
 	// Query-string
 	q := u.Query()
-	for k, v := range b.ev.QueryStringParameters {
+	for k, v := range r.Event.QueryStringParameters {
 		q.Set(k, v)
 	}
 	u.RawQuery = q.Encode()
 
 	// Host
-	u.Host = b.ev.Headers["Host"]
+	u.Host = r.Event.Headers["Host"]
 
-	b.URL = u
-	return nil
+	return u, nil
 }
 
 // ParseBody provides body of the request to the RequestBuilder.
-func (b *RequestBuilder) ParseBody() error {
-	body := b.ev.Body
-	if b.ev.IsBase64Encoded {
-		b, err := base64.StdEncoding.DecodeString(body)
+func (r *Request) ParseBody() error {
+	body := []byte(r.Event.Body)
+	if r.Event.IsBase64Encoded {
+		b, err := base64.StdEncoding.DecodeString(r.Event.Body)
 		if err != nil {
 			return errors.Wrap(err, "decoding base64 body")
 		}
-		body = string(b)
+		body = b
 	}
-
-	b.Body = strings.NewReader(body)
+	r.Body = bytes.NewReader(body)
 	return nil
 }
 
-// CreateRequest provides *http.Request to the RequestBuilder.
-func (b *RequestBuilder) CreateRequest() error {
-	req, err := http.NewRequest(b.ev.HTTPMethod, b.URL.String(), b.Body)
-	if err != nil {
-		return errors.Wrap(err, "creating request")
-	}
+// Transformer transforms event from AWS API Gateway to the http.Request.
+type Transformer func(r *Request)
 
-	b.Request = req
-	return nil
+// Transform AWS API Gateway event to a http.Request.
+func (r *Request) Transform(ts ...Transformer) {
+	for _, p := range ts {
+		p(r)
+	}
 }
 
 // AttachContext attaches events' RequestContext to the http.Request.
-func (b *RequestBuilder) AttachContext() error {
-	b.Request = b.Request.WithContext(NewContext(b.Request.Context(), b.ev))
-	return nil
+func AttachContext(r *Request) {
+	r.Request = r.Request.WithContext(NewContext(r.Request.Context(), r.Event))
 }
 
 // SetRemoteAddr sets RemoteAddr to the request.
-func (b *RequestBuilder) SetRemoteAddr() error {
-	b.Request.RemoteAddr = b.ev.RequestContext.Identity.SourceIP
-	return nil
+func SetRemoteAddr(r *Request) {
+	r.Request.RemoteAddr = r.Event.RequestContext.Identity.SourceIP
 }
 
 // SetHeaderFields sets headers to the request.
-func (b *RequestBuilder) SetHeaderFields() error {
-	for k, v := range b.ev.Headers {
-		b.Request.Header.Set(k, v)
+func SetHeaderFields(r *Request) {
+	for k, v := range r.Event.Headers {
+		r.Request.Header.Set(k, v)
 	}
-	return nil
 }
 
 // SetContentLength sets Content-Length to the request if it has not been set.
-func (b *RequestBuilder) SetContentLength() error {
-	if b.Request.Header.Get("Content-Length") == "" {
-		b.Request.Header.Set("Content-Length", strconv.Itoa(b.Body.Len()))
+func SetContentLength(r *Request) {
+	if r.Request.Header.Get("Content-Length") == "" {
+		r.Request.Header.Set("Content-Length", strconv.Itoa(r.Body.Len()))
 	}
-	return nil
 }
 
-// SetCustomHeaders sets additional headers from the event's RequestContext to
-// the request.
-func (b *RequestBuilder) SetCustomHeaders() error {
-	b.Request.Header.Set("X-Request-Id", b.ev.RequestContext.RequestID)
-	b.Request.Header.Set("X-Stage", b.ev.RequestContext.Stage)
-	return nil
+// SetCustomHeaders assigns X-Request-Id and X-Stage from the event's
+// Request Context.
+func SetCustomHeaders(r *Request) {
+	r.Request.Header.Set("X-Request-Id", r.Event.RequestContext.RequestID)
+	r.Request.Header.Set("X-Stage", r.Event.RequestContext.Stage)
 }
 
 // SetXRayHeader sets AWS X-Ray Trace ID from the event's context.
-func (b *RequestBuilder) SetXRayHeader() error {
-	if traceID := b.ctx.Value("x-amzn-trace-id"); traceID != nil {
-		b.Request.Header.Set("X-Amzn-Trace-Id", fmt.Sprintf("%v", traceID))
+func SetXRayHeader(r *Request) {
+	if traceID := r.Context.Value("x-amzn-trace-id"); traceID != nil {
+		r.Request.Header.Set("X-Amzn-Trace-Id", fmt.Sprintf("%v", traceID))
 	}
-	return nil
 }

--- a/request.go
+++ b/request.go
@@ -99,8 +99,10 @@ func (r *Request) ParseURL() (*url.URL, error) {
 
 	// Query-string
 	q := u.Query()
-	for k, v := range r.Event.QueryStringParameters {
-		q.Set(k, v)
+	for k, qs := range r.Event.MultiValueQueryStringParameters {
+		for _, v := range qs {
+			q.Add(k, v)
+		}
 	}
 	u.RawQuery = q.Encode()
 
@@ -146,8 +148,10 @@ func SetRemoteAddr(r *Request) {
 
 // SetHeaderFields sets headers to the request.
 func SetHeaderFields(r *Request) {
-	for k, v := range r.Event.Headers {
-		r.Request.Header.Set(k, v)
+	for k, hs := range r.Event.MultiValueHeaders {
+		for _, v := range hs {
+			r.Request.Header.Add(k, v)
+		}
 	}
 }
 

--- a/request.go
+++ b/request.go
@@ -38,7 +38,7 @@ func NewRequest(ctx context.Context, ev events.APIGatewayProxyRequest) *Request 
 
 // StripBasePath removes a BasePath from the Path fragment of the URL.
 // StripBasePath must be run before RequestBuilder.ParseURL function.
-func StripBasePath(r *Request, basePath string) {
+func (r *Request) StripBasePath(basePath string) {
 	r.Path = omitBasePath(r.Event.Path, basePath)
 }
 
@@ -121,17 +121,17 @@ func (r *Request) ParseBody() error {
 }
 
 // AttachContext attaches events' RequestContext to the http.Request.
-func AttachContext(r *Request) {
+func (r *Request) AttachContext() {
 	r.Request = r.Request.WithContext(NewContext(r.Context, r.Event))
 }
 
 // SetRemoteAddr sets RemoteAddr to the request.
-func SetRemoteAddr(r *Request) {
+func (r *Request) SetRemoteAddr() {
 	r.Request.RemoteAddr = r.Event.RequestContext.Identity.SourceIP
 }
 
 // SetHeaderFields sets headers to the request.
-func SetHeaderFields(r *Request) {
+func (r *Request) SetHeaderFields() {
 	for k, hs := range r.Event.MultiValueHeaders {
 		for _, v := range hs {
 			r.Request.Header.Add(k, v)
@@ -140,7 +140,7 @@ func SetHeaderFields(r *Request) {
 }
 
 // SetContentLength sets Content-Length to the request if it has not been set.
-func SetContentLength(r *Request) {
+func (r *Request) SetContentLength() {
 	if r.Request.Header.Get("Content-Length") == "" {
 		r.Request.Header.Set("Content-Length", strconv.Itoa(r.Body.Len()))
 	}
@@ -148,13 +148,13 @@ func SetContentLength(r *Request) {
 
 // SetCustomHeaders assigns X-Request-Id and X-Stage from the event's
 // Request Context.
-func SetCustomHeaders(r *Request) {
+func (r *Request) SetCustomHeaders() {
 	r.Request.Header.Set("X-Request-Id", r.Event.RequestContext.RequestID)
 	r.Request.Header.Set("X-Stage", r.Event.RequestContext.Stage)
 }
 
 // SetXRayHeader sets AWS X-Ray Trace ID from the event's context.
-func SetXRayHeader(r *Request) {
+func (r *Request) SetXRayHeader() {
 	if traceID := r.Context.Value("x-amzn-trace-id"); traceID != nil {
 		r.Request.Header.Set("X-Amzn-Trace-Id", fmt.Sprintf("%v", traceID))
 	}

--- a/request.go
+++ b/request.go
@@ -138,7 +138,7 @@ func (r *Request) Transform(ts ...Transformer) {
 
 // AttachContext attaches events' RequestContext to the http.Request.
 func AttachContext(r *Request) {
-	r.Request = r.Request.WithContext(NewContext(r.Request.Context(), r.Event))
+	r.Request = r.Request.WithContext(NewContext(r.Context, r.Event))
 }
 
 // SetRemoteAddr sets RemoteAddr to the request.

--- a/request_test.go
+++ b/request_test.go
@@ -136,16 +136,16 @@ func TestNewRequest_bodyBinary(t *testing.T) {
 func customProxyStripPath(event events.APIGatewayProxyRequest, basePath string) (*http.Request, error) {
 	r := NewRequest(context.TODO(), event)
 
-	StripBasePath(r, basePath)
+	r.StripBasePath(basePath)
 
 	if err := r.CreateRequest(); err != nil {
 		return nil, err
 	}
 
-	SetRemoteAddr(r)
-	SetHeaderFields(r)
-	SetContentLength(r)
-	SetXRayHeader(r)
+	r.SetRemoteAddr()
+	r.SetHeaderFields()
+	r.SetContentLength()
+	r.SetXRayHeader()
 
 	return r.Request, nil
 }

--- a/request_test.go
+++ b/request_test.go
@@ -39,9 +39,9 @@ func TestNewRequest_queryString(t *testing.T) {
 	e := events.APIGatewayProxyRequest{
 		HTTPMethod: "GET",
 		Path:       "/pets",
-		QueryStringParameters: map[string]string{
-			"order":  "desc",
-			"fields": "name,species",
+		MultiValueQueryStringParameters: map[string][]string{
+			"order":  {"desc"},
+			"fields": {"name,species"},
 		},
 	}
 
@@ -78,6 +78,11 @@ func TestNewRequest_header(t *testing.T) {
 			"Content-Type": "application/json",
 			"X-Foo":        "bar",
 			"Host":         "example.com",
+		},
+		MultiValueHeaders: map[string][]string{
+			"Content-Type": {"application/json"},
+			"X-Foo":        {"bar"},
+			"Host":         {"example.com"},
 		},
 		RequestContext: events.APIGatewayProxyRequestContext{
 			RequestID: "1234",
@@ -150,8 +155,8 @@ func customProxyStripPath(event events.APIGatewayProxyRequest, basePath string) 
 
 func TestStripBasePath_executeapi(t *testing.T) {
 	e := events.APIGatewayProxyRequest{
-		Headers: map[string]string{
-			"Host": "xxxxxxxxxx.execute-api.us-east-1.amazonaws.com",
+		MultiValueHeaders: map[string][]string{
+			"Host": {"xxxxxxxxxx.execute-api.us-east-1.amazonaws.com"},
 		},
 		RequestContext: events.APIGatewayProxyRequestContext{
 			Stage: "testing",
@@ -178,6 +183,9 @@ func TestStripBasePath_customDomain(t *testing.T) {
 		Headers: map[string]string{
 			"Host": "api.example.com",
 		},
+		MultiValueHeaders: map[string][]string{
+			"Host": {"api.example.com"},
+		},
 		RequestContext: events.APIGatewayProxyRequestContext{
 			Stage: "testing",
 		},
@@ -202,6 +210,9 @@ func TestStripBasePath_noBasePath(t *testing.T) {
 	e := events.APIGatewayProxyRequest{
 		Headers: map[string]string{
 			"Host": "api.example.com",
+		},
+		MultiValueHeaders: map[string][]string{
+			"Host": {"api.example.com"},
 		},
 		RequestContext: events.APIGatewayProxyRequestContext{
 			Stage: "testing",

--- a/request_test.go
+++ b/request_test.go
@@ -136,18 +136,16 @@ func TestNewRequest_bodyBinary(t *testing.T) {
 func customProxyStripPath(event events.APIGatewayProxyRequest, basePath string) (*http.Request, error) {
 	r := NewRequest(context.TODO(), event)
 
-	StripBasePath(basePath)(r)
+	StripBasePath(r, basePath)
 
 	if err := r.CreateRequest(); err != nil {
 		return nil, err
 	}
 
-	r.Transform(
-		SetRemoteAddr,
-		SetHeaderFields,
-		SetContentLength,
-		SetXRayHeader,
-	)
+	SetRemoteAddr(r)
+	SetHeaderFields(r)
+	SetContentLength(r)
+	SetXRayHeader(r)
 
 	return r.Request, nil
 }

--- a/request_test.go
+++ b/request_test.go
@@ -15,7 +15,7 @@ func TestNewRequest_path(t *testing.T) {
 		Path: "/pets/luna",
 	}
 
-	r, err := DefaultProxy(context.Background(), e)
+	r, err := new(DefaultProxy).Transform(context.TODO(), e)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "GET", r.Method)
@@ -29,7 +29,7 @@ func TestNewRequest_method(t *testing.T) {
 		Path:       "/pets/luna",
 	}
 
-	r, err := DefaultProxy(context.Background(), e)
+	r, err := new(DefaultProxy).Transform(context.TODO(), e)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "DELETE", r.Method)
@@ -45,7 +45,7 @@ func TestNewRequest_queryString(t *testing.T) {
 		},
 	}
 
-	r, err := DefaultProxy(context.Background(), e)
+	r, err := new(DefaultProxy).Transform(context.TODO(), e)
 	assert.NoError(t, err)
 
 	assert.Equal(t, `/pets?fields=name%2Cspecies&order=desc`, r.URL.String())
@@ -63,7 +63,7 @@ func TestNewRequest_remoteAddr(t *testing.T) {
 		},
 	}
 
-	r, err := DefaultProxy(context.Background(), e)
+	r, err := new(DefaultProxy).Transform(context.TODO(), e)
 	assert.NoError(t, err)
 
 	assert.Equal(t, `1.2.3.4`, r.RemoteAddr)
@@ -77,12 +77,10 @@ func TestNewRequest_header(t *testing.T) {
 		Headers: map[string]string{
 			"Content-Type": "application/json",
 			"X-Foo":        "bar",
-			"Host":         "example.com",
 		},
 		MultiValueHeaders: map[string][]string{
 			"Content-Type": {"application/json"},
 			"X-Foo":        {"bar"},
-			"Host":         {"example.com"},
 		},
 		RequestContext: events.APIGatewayProxyRequestContext{
 			RequestID: "1234",
@@ -90,10 +88,11 @@ func TestNewRequest_header(t *testing.T) {
 		},
 	}
 
-	r, err := DefaultProxy(context.Background(), e)
+	p := &DefaultProxy{Host: "api.example.com"}
+	r, err := p.Transform(context.TODO(), e)
 	assert.NoError(t, err)
 
-	assert.Equal(t, `example.com`, r.Host)
+	assert.Equal(t, `api.example.com`, r.Host)
 	assert.Equal(t, `prod`, r.Header.Get("X-Stage"))
 	assert.Equal(t, `1234`, r.Header.Get("X-Request-Id"))
 	assert.Equal(t, `18`, r.Header.Get("Content-Length"))
@@ -108,7 +107,7 @@ func TestNewRequest_body(t *testing.T) {
 		Body:       `{ "name": "Tobi" }`,
 	}
 
-	r, err := DefaultProxy(context.Background(), e)
+	r, err := new(DefaultProxy).Transform(context.TODO(), e)
 	assert.NoError(t, err)
 
 	b, err := ioutil.ReadAll(r.Body)
@@ -125,7 +124,7 @@ func TestNewRequest_bodyBinary(t *testing.T) {
 		IsBase64Encoded: true,
 	}
 
-	r, err := DefaultProxy(context.Background(), e)
+	r, err := new(DefaultProxy).Transform(context.TODO(), e)
 	assert.NoError(t, err)
 
 	b, err := ioutil.ReadAll(r.Body)


### PR DESCRIPTION
To-Do:

- [X] Add benchmark to make clear what is an improvement between the V1 and V2.
- [X] Improve code documentation. Note about async - gouroutines and timeouts.
- [X] Drop compatibility with apex/gateway. 
- [X] Use new `MultiValueQueryStringParameters` and `MultiValueHeaders`.
- [X] Fix for empty context after transformation - https://github.com/apex/gateway/pull/13 
- [X] Extensible and customizable.
- [x] Investigate if there is a possible attack using spoofed headers (and fix it them too).
- [X] ~Check if `apigo` supports `ALB`~. `wontfix` (it's better to create a fork and replace the type of the event - I haven't used ALB with Lambda yet).